### PR TITLE
[DEV-4686] Fix - Empty paragraph collapsing

### DIFF
--- a/sandbox/story.json
+++ b/sandbox/story.json
@@ -29,6 +29,22 @@
             "type": "paragraph",
             "children": [
                 {
+                    "text": ""
+                }
+            ]
+        },
+        {
+            "type": "paragraph",
+            "children": [
+                {
+                    "text": "Paragraph    with   additional    whitespaces."
+                }
+            ]
+        },
+        {
+            "type": "paragraph",
+            "children": [
+                {
                     "text": "Placeholder: "
                 },
                 {

--- a/src/Renderer.test.tsx
+++ b/src/Renderer.test.tsx
@@ -30,7 +30,7 @@ describe('Renderer', () => {
         const asString = ReactDOMServer.renderToString(
             <Renderer
                 nodes={documentNode}
-                options={{
+                components={{
                     [DIVIDER_NODE_TYPE]: () => <section>divider</section>,
                 }}
             />,

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -1,22 +1,31 @@
-import { isElementNode, isTextNode } from '@prezly/slate-types';
+import { isElementNode, isTextNode, Node } from '@prezly/slate-types';
 import React, { Fragment, FunctionComponent } from 'react';
 
 import { defaultComponents } from './defaultComponents';
-import { stringifyNode } from './lib';
-import type { Node, ComponentRenderers } from './types';
+import { applyTransformations, stringifyNode } from './lib';
+import * as Transformations from './transformations';
+import type { ComponentRenderers, Transformation } from './types';
 
 interface Props {
     nodes: Node | Node[];
     components?: ComponentRenderers;
+    transformations?: Transformation[];
 }
 
-export const Renderer: FunctionComponent<Props> = ({ nodes, components: userComponents = {} }) => {
-    const nodesArray = Array.isArray(nodes) ? nodes : [nodes];
+export const Renderer: FunctionComponent<Props> = ({
+    nodes,
+    components: userComponents = {},
+    transformations = Object.values(Transformations),
+}) => {
     const components = { ...defaultComponents, ...userComponents };
+    const transformedNodes = applyTransformations(
+        Array.isArray(nodes) ? nodes : [nodes],
+        transformations,
+    );
 
     return (
         <>
-            {nodesArray.map((node, index) => {
+            {transformedNodes.map((node, index) => {
                 if (isTextNode(node)) {
                     const TextRenderer = components.text;
                     return <TextRenderer key={index} {...node} />;

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -33,15 +33,19 @@ export const Renderer: FunctionComponent<Props> = ({
 
                 if (isElementNode(node)) {
                     const { children, type } = node;
-                    const NodeRenderer = components[type as keyof ComponentRenderers];
+                    const ComponentRenderer = components[type as keyof ComponentRenderers];
 
-                    if (NodeRenderer) {
+                    if (ComponentRenderer) {
                         return (
-                            // @ts-ignore
-                            <NodeRenderer key={index} node={node}>
+                            /* @ts-ignore */
+                            <ComponentRenderer key={index} node={node}>
                                 {/* @ts-ignore */}
-                                <Renderer nodes={children} components={components} />
-                            </NodeRenderer>
+                                <Renderer
+                                    nodes={children as Node[]}
+                                    components={components}
+                                    transformations={transformations}
+                                />
+                            </ComponentRenderer>
                         );
                     }
                 }

--- a/src/Renderer.tsx
+++ b/src/Renderer.tsx
@@ -1,37 +1,37 @@
 import { isElementNode, isTextNode } from '@prezly/slate-types';
 import React, { Fragment, FunctionComponent } from 'react';
 
-import { defaultOptions } from './defaultOptions';
+import { defaultComponents } from './defaultComponents';
 import { stringifyNode } from './lib';
-import type { Node, Options } from './types';
+import type { Node, ComponentRenderers } from './types';
 
 interface Props {
     nodes: Node | Node[];
-    options?: Options;
+    components?: ComponentRenderers;
 }
 
-export const Renderer: FunctionComponent<Props> = ({ nodes, options: userOptions = {} }) => {
+export const Renderer: FunctionComponent<Props> = ({ nodes, components: userComponents = {} }) => {
     const nodesArray = Array.isArray(nodes) ? nodes : [nodes];
-    const options = { ...defaultOptions, ...userOptions };
+    const components = { ...defaultComponents, ...userComponents };
 
     return (
         <>
             {nodesArray.map((node, index) => {
                 if (isTextNode(node)) {
-                    const TextRenderer = options.text;
+                    const TextRenderer = components.text;
                     return <TextRenderer key={index} {...node} />;
                 }
 
                 if (isElementNode(node)) {
                     const { children, type } = node;
-                    const NodeRenderer = options[type as keyof Options];
+                    const NodeRenderer = components[type as keyof ComponentRenderers];
 
                     if (NodeRenderer) {
                         return (
                             // @ts-ignore
                             <NodeRenderer key={index} node={node}>
                                 {/* @ts-ignore */}
-                                <Renderer nodes={children} options={options} />
+                                <Renderer nodes={children} components={components} />
                             </NodeRenderer>
                         );
                     }

--- a/src/defaultComponents.tsx
+++ b/src/defaultComponents.tsx
@@ -42,9 +42,9 @@ import {
     Placeholder,
     Quote,
 } from './elements';
-import type { Options } from './types';
+import type { ComponentRenderers } from './types';
 
-export const defaultOptions: Required<Options> = {
+export const defaultComponents: Required<ComponentRenderers> = {
     [ATTACHMENT_NODE_TYPE]: Attachment,
     [BULLETED_LIST_NODE_TYPE]: BulletedList,
     [CONTACT_NODE_TYPE]: Contact,

--- a/src/elements/Paragraph/Paragraph.scss
+++ b/src/elements/Paragraph/Paragraph.scss
@@ -7,7 +7,3 @@
     font-size: $font-size-m;
     line-height: $line-height;
 }
-
-.prezly-slate-paragraph:empty::before {
-    content: "\00a0"; // prevent completely empty paragraph from collapsing
-}

--- a/src/elements/Paragraph/Paragraph.tsx
+++ b/src/elements/Paragraph/Paragraph.tsx
@@ -2,8 +2,6 @@ import type { ParagraphNode } from '@prezly/slate-types';
 import classNames from 'classnames';
 import React, { FunctionComponent, HTMLAttributes } from 'react';
 
-import { stringifyReactNode } from '../../lib';
-
 import './Paragraph.scss';
 
 interface Props extends HTMLAttributes<HTMLParagraphElement> {
@@ -13,6 +11,5 @@ interface Props extends HTMLAttributes<HTMLParagraphElement> {
 export const Paragraph: FunctionComponent<Props> = ({ children, className, node, ...props }) => (
     <p className={classNames('prezly-slate-paragraph', className)} {...props}>
         {children}
-        {stringifyReactNode(children).trim().length === 0 && <>&nbsp;</>}
     </p>
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { defaultOptions } from './defaultOptions';
+export { defaultComponents } from './defaultComponents';
 export {
     Attachment,
     BulletedList,
@@ -20,4 +20,4 @@ export {
     Placeholder,
 } from './elements';
 export { Renderer } from './Renderer';
-export type { Node, NodeRenderer, TextRenderer, Options } from './types';
+export type { Node, NodeRenderer, TextRenderer, ComponentRenderers } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import * as Transformations from './transformations';
+
+export type { NodeRenderer, TextRenderer, ComponentRenderers } from './types';
 export { defaultComponents } from './defaultComponents';
 export {
     Attachment,
@@ -20,4 +23,4 @@ export {
     Placeholder,
 } from './elements';
 export { Renderer } from './Renderer';
-export type { Node, NodeRenderer, TextRenderer, ComponentRenderers } from './types';
+export { Transformations };

--- a/src/lib/applyTransformations.ts
+++ b/src/lib/applyTransformations.ts
@@ -1,0 +1,54 @@
+import type { Node } from '@prezly/slate-types';
+
+import type { Transformation } from '../types';
+import { isElementNode } from '@prezly/slate-types';
+
+function applyTransformationsWithoutRecursion(
+    node: Node,
+    transformations: Transformation[],
+): Node | null {
+    return transformations.reduce<Node | null>(
+        (result, transform) => (result ? transform(result) : null),
+        node,
+    );
+}
+
+export function applyTransformations(node: Node, transformations: Transformation[]): Node | null;
+export function applyTransformations(nodes: Node[], transformations: Transformation[]): Node[];
+export function applyTransformations(
+    input: Node | Node[],
+    transformations: Transformation[],
+): Node[] | Node | null {
+    if (transformations.length === 0) {
+        return input;
+    }
+
+    if (Array.isArray(input)) {
+        const nodes = input
+            .map((node) => applyTransformations(node, transformations))
+            .filter((node): node is Node => Boolean(node));
+
+        if (nodes.every((node, index) => input[index] === node)) {
+            // No changes => return exactly the same input array
+            return input;
+        }
+
+        return nodes;
+    }
+
+    if (isElementNode(input)) {
+        let element = input;
+
+        // Transform children first
+        const children: Node[] = applyTransformations(input.children as Node[], transformations);
+
+        if (children !== input.children) {
+            // Create a new node object only if there's a change
+            element = { ...input, children };
+        }
+
+        return applyTransformationsWithoutRecursion(element, transformations);
+    }
+
+    return applyTransformationsWithoutRecursion(input as Node, transformations);
+}

--- a/src/lib/applyTransformations.ts
+++ b/src/lib/applyTransformations.ts
@@ -28,7 +28,7 @@ export function applyTransformations(
             .map((node) => applyTransformations(node, transformations))
             .filter((node): node is Node => Boolean(node));
 
-        if (nodes.every((node, index) => input[index] === node)) {
+        if (nodes.length === input.length && nodes.every((node, index) => input[index] === node)) {
             // No changes => return exactly the same input array
             return input;
         }

--- a/src/lib/applyTransrformations.test.ts
+++ b/src/lib/applyTransrformations.test.ts
@@ -10,6 +10,13 @@ function makeBold(node: Node): Node {
     return node;
 }
 
+function removeWorld(node: Node): Node | null {
+    if (isTextNode(node) && node.text === 'world') {
+        return null;
+    }
+    return node;
+}
+
 describe('applyTransformations', () => {
     it('should return exactly the same input if no transformations provided', () => {
         const input: Node[] = [
@@ -103,5 +110,25 @@ describe('applyTransformations', () => {
         Object.freeze(input);
 
         expect(applyTransformations(input, [makeBold])).toEqual(expected);
+    });
+
+    it('should remove node if transformation returned null', () => {
+        const input: Node = {
+            type: 'paragraph',
+            children: [
+                { text: 'hello', bold: true } as TextNode,
+                { text: 'world', italic: true } as TextNode,
+            ],
+        };
+        const expected = {
+            type: 'paragraph',
+            children: [
+                { text: 'hello', bold: true },
+            ],
+        };
+
+        Object.freeze(input);
+
+        expect(applyTransformations(input, [removeWorld])).toEqual(expected);
     });
 });

--- a/src/lib/applyTransrformations.test.ts
+++ b/src/lib/applyTransrformations.test.ts
@@ -1,0 +1,107 @@
+import type { Node, TextNode } from '@prezly/slate-types';
+import { isTextNode } from '@prezly/slate-types';
+
+import { applyTransformations } from './applyTransformations';
+
+function makeBold(node: Node): Node {
+    if (isTextNode(node)) {
+        return { ...node, bold: true };
+    }
+    return node;
+}
+
+describe('applyTransformations', () => {
+    it('should return exactly the same input if no transformations provided', () => {
+        const input: Node[] = [
+            {
+                type: 'paragraph',
+                children: [
+                    { text: 'hello', bold: true } as TextNode,
+                    { text: 'world', italic: true } as TextNode,
+                ],
+            },
+            {
+                type: 'paragraph',
+                children: [{ text: 'this is Prezly', underlined: true } as TextNode],
+            },
+        ];
+
+        Object.freeze(input);
+
+        expect(applyTransformations(input, [])).toBe(input);
+    });
+
+    it('should return exactly the same input if no transformations applied', () => {
+        const input: Node[] = [
+            {
+                type: 'paragraph',
+                children: [
+                    { text: 'hello', bold: true } as TextNode,
+                    { text: 'world', italic: true } as TextNode,
+                ],
+            },
+            {
+                type: 'paragraph',
+                children: [{ text: 'this is Prezly', underlined: true } as TextNode],
+            },
+        ];
+
+        Object.freeze(input);
+
+        expect(applyTransformations(input, [(node) => node])).toBe(input);
+    });
+
+    it('should run transformation for all nodes recursively', () => {
+        const input: Node = {
+            type: 'paragraph',
+            children: [
+                { text: 'hello', bold: true } as TextNode,
+                { text: 'world', italic: true } as TextNode,
+            ],
+        };
+        const expected = {
+            type: 'paragraph',
+            children: [
+                { text: 'hello', bold: true } as TextNode,
+                { text: 'world', bold: true, italic: true } as TextNode,
+            ],
+        };
+
+        Object.freeze(input);
+
+        expect(applyTransformations(input, [makeBold])).toEqual(expected);
+    });
+
+    it('should apply transformations to a list of nodes recursively', () => {
+        const input: Node[] = [
+            {
+                type: 'paragraph',
+                children: [
+                    { text: 'hello', bold: true } as TextNode,
+                    { text: 'world', italic: true } as TextNode,
+                ],
+            },
+            {
+                type: 'paragraph',
+                children: [{ text: 'this is Prezly', underlined: true } as TextNode],
+            },
+        ];
+        const expected = [
+            {
+                type: 'paragraph',
+                children: [
+                    { text: 'hello', bold: true } as TextNode,
+                    { text: 'world', bold: true, italic: true } as TextNode,
+                ],
+            },
+            {
+                type: 'paragraph',
+                children: [{ text: 'this is Prezly', bold: true, underlined: true } as TextNode],
+            },
+        ];
+
+        Object.freeze(input);
+
+        expect(applyTransformations(input, [makeBold])).toEqual(expected);
+    });
+});

--- a/src/lib/applyTransrformations.test.ts
+++ b/src/lib/applyTransrformations.test.ts
@@ -122,9 +122,7 @@ describe('applyTransformations', () => {
         };
         const expected = {
             type: 'paragraph',
-            children: [
-                { text: 'hello', bold: true },
-            ],
+            children: [{ text: 'hello', bold: true }],
         };
 
         Object.freeze(input);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
+export { applyTransformations } from './applyTransformations';
 export { formatBytes } from './formatBytes';
 export { identity } from './identity';
 export { noop } from './noop';

--- a/src/lib/stringifyNode.ts
+++ b/src/lib/stringifyNode.ts
@@ -1,4 +1,4 @@
-import type { Node } from '../types';
+import type { Node } from '@prezly/slate-types';
 
 /**
  * Stringify Slate node for debug purposes (e.g. error messages).

--- a/src/transformations/index.ts
+++ b/src/transformations/index.ts
@@ -1,0 +1,2 @@
+export { preventEmptyBlockCollapsing } from './preventEmptyBlockCollapsing';
+export { preventWhitespaceCollapsing } from './preventWhitepaceCollapsing';

--- a/src/transformations/preventEmptyBlockCollapsing.ts
+++ b/src/transformations/preventEmptyBlockCollapsing.ts
@@ -1,0 +1,25 @@
+import type { Node } from '@prezly/slate-types';
+import { isElementNode, isTextNode } from '@prezly/slate-types';
+
+function isEmpty(node: Node): boolean {
+    if (isTextNode(node)) {
+        return node.text.length === 0;
+    }
+
+    if (isElementNode(node)) {
+        return node.children.every((node) => isEmpty(node as Node));
+    }
+
+    return false;
+}
+
+export function preventEmptyBlockCollapsing(node: Node): Node {
+    if (isElementNode(node) && isEmpty(node)) {
+        return {
+            ...node,
+            children: [...node.children, { text: '\u00a0' }],
+        };
+    }
+
+    return node;
+}

--- a/src/transformations/preventWhitepaceCollapsing.ts
+++ b/src/transformations/preventWhitepaceCollapsing.ts
@@ -1,0 +1,10 @@
+import { isTextNode, Node } from '@prezly/slate-types';
+
+export function preventWhitespaceCollapsing(node: Node): Node {
+    if (isTextNode(node)) {
+        const text = node.text.replace(/\s\s/g, ' \u00A0');
+        return { ...node, text };
+    }
+
+    return node;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export type NodeRenderer<T extends Node> = FunctionComponent<{ node: T }>;
 
 export type TextRenderer = FunctionComponent<TextNode & { children?: never }>;
 
-export interface Options {
+export interface ComponentRenderers {
     [ATTACHMENT_NODE_TYPE]?: NodeRenderer<AttachmentNode>;
     [BULLETED_LIST_NODE_TYPE]?: NodeRenderer<ListNode>;
     [CONTACT_NODE_TYPE]?: NodeRenderer<ContactNode>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,6 @@ import {
     CoverageNode,
     DividerNode,
     DocumentNode,
-    ElementNode,
     EmbedNode,
     GalleryNode,
     HeadingNode,
@@ -33,14 +32,13 @@ import {
     ListItemTextNode,
     ListNode,
     MentionNode,
+    Node,
     ParagraphNode,
     PlaceholderNode,
     QuoteNode,
     TextNode,
 } from '@prezly/slate-types';
 import type { FunctionComponent } from 'react';
-
-export type Node = ElementNode | TextNode;
 
 export type NodeRenderer<T extends Node> = FunctionComponent<{ node: T }>;
 
@@ -68,3 +66,5 @@ export interface ComponentRenderers {
     [QUOTE_NODE_TYPE]?: NodeRenderer<QuoteNode>;
     text?: TextRenderer;
 }
+
+export type Transformation = (node: Node) => Node | null;


### PR DESCRIPTION
- Add `transformations` functionality to the renderer with defaults to prevent collapsing whitespace and empty paragraphs.
- Rename `options` property to `components`, as it does make more sense to see it next to `transformations`

Before:

<img src="https://user-images.githubusercontent.com/370680/148077212-2bdb004c-dbba-4596-bb3f-e7e282d7b664.png" width=400>

After:

<img src=https://user-images.githubusercontent.com/370680/148077226-287b3358-478e-4b94-81b9-930820e4f701.png width=400>

Source JSON:

```json
{
    "type": "paragraph",
    "children": [
        {
            "text": "Paragraph"
        }
    ]
},
{
    "type": "paragraph",
    "children": [
        {
            "text": ""
        }
    ]
},
{
    "type": "paragraph",
    "children": [
        {
            "text": "Paragraph    with   additional    whitespaces."
        }
    ]
},
```