### PR TITLE
[TITS-4886] Added onDownload and onPreview callbacks to Image and Gallery elements

### DIFF
--- a/src/components/Lightbox/Lightbox.tsx
+++ b/src/components/Lightbox/Lightbox.tsx
@@ -1,7 +1,7 @@
 import type { UploadcareImage } from '@prezly/slate-types';
 import { useEventListener } from '@react-hookz/web';
 import classNames from 'classnames';
-import React, { FunctionComponent, KeyboardEvent, ReactNode } from 'react';
+import React, { FunctionComponent, KeyboardEvent, ReactNode, useEffect } from 'react';
 import Modal from 'react-modal';
 
 import { ChevronLeft, ChevronRight, Close } from '../../icons';
@@ -19,7 +19,9 @@ interface Props {
     isNextEnabled?: boolean;
     isPreviousEnabled?: boolean;
     onClose: () => void;
+    onDownload?: (image: UploadcareImage) => void;
     onNext?: () => void;
+    onOpen?: (image: UploadcareImage) => void;
     onPrevious?: () => void;
 }
 
@@ -30,7 +32,9 @@ export const Lightbox: FunctionComponent<Props> = ({
     isNextEnabled,
     isPreviousEnabled,
     onClose,
+    onDownload = noop,
     onNext = noop,
+    onOpen = noop,
     onPrevious = noop,
 }) => {
     useEventListener(
@@ -54,6 +58,12 @@ export const Lightbox: FunctionComponent<Props> = ({
             }
         },
     );
+
+    useEffect(() => {
+        if (image) {
+            onOpen(image);
+        }
+    }, [image]);
 
     if (typeof window === 'undefined') {
         // Do not render Lightbox outside of browser environment (i.e. SSR)
@@ -105,6 +115,7 @@ export const Lightbox: FunctionComponent<Props> = ({
                             rel="noreferrer noopener"
                             target="_blank"
                             title="Download"
+                            onClick={() => onDownload(image)}
                         >
                             Download
                         </a>

--- a/src/elements/Gallery/Gallery.tsx
+++ b/src/elements/Gallery/Gallery.tsx
@@ -1,4 +1,4 @@
-import type { GalleryNode } from '@prezly/slate-types';
+import type { GalleryNode, UploadcareImage } from '@prezly/slate-types';
 import { useMeasure } from '@react-hookz/web';
 import classNames from 'classnames';
 import React, { FunctionComponent, HTMLAttributes, useMemo } from 'react';
@@ -14,12 +14,16 @@ interface Props extends HTMLAttributes<HTMLElement> {
     children?: never;
     node: GalleryNode;
     maxViewportWidth?: number;
+    onImageDownload?: (image: UploadcareImage) => void;
+    onPreviewOpen?: (image: UploadcareImage) => void;
 }
 
 export const Gallery: FunctionComponent<Props> = ({
     className,
     maxViewportWidth = DEFAULT_MAX_VIEWPORT_WIDTH,
     node,
+    onImageDownload,
+    onPreviewOpen,
     ...props
 }) => {
     const [rect, ref] = useMeasure<HTMLDivElement>();
@@ -62,7 +66,9 @@ export const Gallery: FunctionComponent<Props> = ({
                 isNextEnabled={isNextEnabled}
                 isPreviousEnabled={isPreviousEnabled}
                 onClose={onClose}
+                onDownload={onImageDownload}
                 onNext={onNext}
+                onOpen={onPreviewOpen}
                 onPrevious={onPrevious}
             >
                 {image?.caption}

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -1,6 +1,6 @@
 import { ImageNode, UploadcareImage } from '@prezly/slate-types';
 import classNames from 'classnames';
-import React, { CSSProperties, FunctionComponent, HTMLAttributes, useState } from 'react';
+import React, { CSSProperties, FunctionComponent, HTMLAttributes, useMemo, useState } from 'react';
 
 import { Lightbox, Media, Rollover } from '../../components';
 
@@ -8,6 +8,8 @@ import './Image.scss';
 
 interface Props extends HTMLAttributes<HTMLElement> {
     node: ImageNode;
+    onDownload?: (image: UploadcareImage) => void;
+    onPreviewOpen?: (image: UploadcareImage) => void;
 }
 
 const getContainerStyle = (node: ImageNode): CSSProperties => {
@@ -24,10 +26,17 @@ const getContainerStyle = (node: ImageNode): CSSProperties => {
     return { width };
 };
 
-export const Image: FunctionComponent<Props> = ({ children, className, node, ...props }) => {
+export const Image: FunctionComponent<Props> = ({
+    children,
+    className,
+    node,
+    onDownload,
+    onPreviewOpen,
+    ...props
+}) => {
     const { file, href, layout } = node;
     const [isPreviewOpen, setIsPreviewOpen] = useState<boolean>(false);
-    const image = UploadcareImage.createFromPrezlyStoragePayload(file);
+    const image = useMemo(() => UploadcareImage.createFromPrezlyStoragePayload(file), [file.uuid]);
     const containerStyle = getContainerStyle(node);
     const handleRolloverClick = () => setIsPreviewOpen(true);
     const handleImagePreviewClose = () => setIsPreviewOpen(false);
@@ -70,7 +79,12 @@ export const Image: FunctionComponent<Props> = ({ children, className, node, ...
 
             <figcaption className="prezly-slate-image__caption">{children}</figcaption>
 
-            <Lightbox image={isPreviewOpen ? image : null} onClose={handleImagePreviewClose}>
+            <Lightbox
+                image={isPreviewOpen ? image : null}
+                onClose={handleImagePreviewClose}
+                onDownload={onDownload}
+                onOpen={onPreviewOpen}
+            >
                 {children}
             </Lightbox>
         </figure>


### PR DESCRIPTION
Adding these callbacks is required to allow tracking of image views and downloads (for https://linear.app/prezly/issue/TITS-4886/setup-additional-events-for-user-interactions).

Only other approach I can think of would be to roll our own Lightbox implementation but that felt like overkill.