### PR TITLE
[QRF-113] Strip <script> tags from the injected HTML

### DIFF
--- a/src/components/HtmlInjection.tsx
+++ b/src/components/HtmlInjection.tsx
@@ -38,11 +38,11 @@ function useScripts(html: Props['html'], onError: Props['onError']) {
                 return;
             }
 
-            const scriptElement = document.createElement('script');
-            setScriptAttributes(scriptElement, attributes);
+            const script = document.createElement('script');
+            setScriptAttributes(script, attributes);
 
-            scriptElement.addEventListener('error', onError);
-            document.body.appendChild(scriptElement);
+            script.addEventListener('error', onError);
+            document.body.appendChild(script);
         });
 
         if (typeof iframely !== 'undefined') {


### PR DESCRIPTION
Previous fix to `HtmlInjection` was still leaving the `<script>` tags in the injected markup. This PR fixes that by stripping the inserted HTML of all `<script>` tags. The script insertion logic remained pretty much untouched, only the script attributes collection was moved to the html stripping logic to not iterate over the HTML twice.