### PR TITLE
[CARE-1081] Update deprecated `color-adjust` property

### DIFF
--- a/src/components/Media/Media.scss
+++ b/src/components/Media/Media.scss
@@ -10,7 +10,7 @@
 
         &--image {
             @media print {
-                color-adjust: exact;
+                print-color-adjust: exact;
             }
         }
     }


### PR DESCRIPTION
This fixes this warning we've been having for a really long while now:
```
autoprefixer: Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.
```