### PR TITLE
[DEV-10841] Only create URL if website is defined

### DIFF
--- a/src/elements/Contact/SocialFields.tsx
+++ b/src/elements/Contact/SocialFields.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export const SocialFields: FunctionComponent<Props> = ({ className, contact, layout }) => {
     const { email, phone, mobile } = contact;
-    const website = new URL(contact.website);
+    const website = contact.website ? new URL(contact.website) : null;
     const { facebook, twitter } = getSocialHandles(contact);
 
     if (layout === ContactNode.Layout.SIGNATURE) {


### PR DESCRIPTION
It's possible that `website` is going to be an empty string which will throw an error when trying to create a URL object out of it.