### PR TITLE
[DEV-11577] Fix Content Renderer incompatibility with Next /app router

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/content-renderer-react-js",
-    "version": "0.33.0-0",
+    "version": "0.33.0-1",
     "description": "Render Prezly Content Format documents with React.js",
     "license": "MIT",
     "main": "build/cjs/index.cjs",

--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
         "react-modal": "^3.15.1",
         "resize-observer-polyfill": "^1.5.1",
         "shave": "^2.5.10",
-        "social-links": "^1.10.0",
-        "striptags": "^3.1.1"
+        "social-links": "^1.10.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/content-renderer-react-js",
-    "version": "0.32.1",
+    "version": "0.33.0-0",
     "description": "Render Prezly Content Format documents with React.js",
     "license": "MIT",
     "main": "build/cjs/index.cjs",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "watch:cjs": "gulp watch:cjs",
         "watch:esm": "gulp watch:esm",
         "watch:sass": "gulp watch:sass",
-        "clean": "npm run clean:build && npm run clean:node_modules && npm run clean:package-lock.json",
+        "clean": "npm run clean:build && npm run clean:package-lock.json && npm run clean:node_modules",
         "clean:build": "rimraf build/",
         "clean:node_modules": "rimraf node_modules/",
         "clean:package-lock.json": "rimraf package-lock.json",

--- a/src/components/BookmarkCard/Container.tsx
+++ b/src/components/BookmarkCard/Container.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useResizeObserver } from '@react-hookz/web';
 import classNames from 'classnames';
 import type { PropsWithChildren } from 'react';

--- a/src/components/BookmarkCard/Details.tsx
+++ b/src/components/BookmarkCard/Details.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import classNames from 'classnames';
 import type { PropsWithChildren } from 'react';
 import { useMemo } from 'react';

--- a/src/components/BookmarkCard/Details.tsx
+++ b/src/components/BookmarkCard/Details.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import type { PropsWithChildren } from 'react';
 import { useMemo } from 'react';
 
-import { isEmptyText, stripTags } from '../../lib';
+import { isEmptyText } from '../../lib';
 import { Link } from '../Link';
 
 interface DetailsProps {
@@ -55,7 +55,7 @@ export function Details({
                     href={href}
                     newTab={newTab}
                 >
-                    {stripTags(title)}
+                    {title}
                 </Link>
             )}
 
@@ -68,7 +68,7 @@ export function Details({
                             isDescriptionShort,
                     })}
                 >
-                    {stripTags(description)}
+                    {description}
                 </div>
             )}
 

--- a/src/components/BookmarkCard/Details.tsx
+++ b/src/components/BookmarkCard/Details.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import classNames from 'classnames';
 import type { PropsWithChildren } from 'react';
 import { useMemo } from 'react';

--- a/src/components/HtmlInjection.tsx
+++ b/src/components/HtmlInjection.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { HTMLAttributes, ScriptHTMLAttributes } from 'react';
 import { useEffect, useMemo } from 'react';
 

--- a/src/components/Lightbox/Lightbox.tsx
+++ b/src/components/Lightbox/Lightbox.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { UploadcareImage } from '@prezly/uploadcare';
 import { useEventListener } from '@react-hookz/web';
 import classNames from 'classnames';

--- a/src/components/MultilineEllipsis/MultilineEllipsis.tsx
+++ b/src/components/MultilineEllipsis/MultilineEllipsis.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Component, createRef, memo } from 'react';
 import shave from 'shave';
 

--- a/src/components/PinterestButton/PinterestButton.tsx
+++ b/src/components/PinterestButton/PinterestButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import classNames from 'classnames';
 import type { AnchorHTMLAttributes, MouseEvent } from 'react';
 import { useCallback } from 'react';

--- a/src/components/Rollover/Rollover.tsx
+++ b/src/components/Rollover/Rollover.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMeasure } from '@react-hookz/web';
 import classNames from 'classnames';
 import type { ButtonHTMLAttributes } from 'react';

--- a/src/elements/Embed/Iframe.tsx
+++ b/src/elements/Embed/Iframe.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';
 import { useState } from 'react';

--- a/src/elements/Gallery/Gallery.tsx
+++ b/src/elements/Gallery/Gallery.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { GalleryNode } from '@prezly/story-content-format';
 import { UploadcareImage } from '@prezly/uploadcare';
 import { useMeasure } from '@react-hookz/web';

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { ImageNode } from '@prezly/story-content-format';
 import { UploadcareImage } from '@prezly/uploadcare';
 import classNames from 'classnames';

--- a/src/elements/Table/TableCell.tsx
+++ b/src/elements/Table/TableCell.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { TableCellNode } from '@prezly/story-content-format';
 import classNames from 'classnames';
 import type { HTMLAttributes } from 'react';

--- a/src/elements/Table/TableContext.tsx
+++ b/src/elements/Table/TableContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { TableCellNode } from '@prezly/story-content-format';
 import { TableNode } from '@prezly/story-content-format';
 import type { PropsWithChildren } from 'react';

--- a/src/elements/Video/Video.tsx
+++ b/src/elements/Video/Video.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { VideoNode } from '@prezly/story-content-format';
 import classNames from 'classnames';
 import type { CSSProperties, HTMLAttributes } from 'react';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,6 +5,5 @@ export { identity } from './identity';
 export { noop } from './noop';
 export { openWindow } from './openWindow';
 export { stringifyNode } from './stringifyNode';
-export { stripTags } from './stripTags';
 export { isEmptyText } from './isEmptyText';
 export { normalizeUrl } from './normalizeUrl';

--- a/src/lib/stripTags.tsx
+++ b/src/lib/stripTags.tsx
@@ -1,9 +1,0 @@
-import striptags from 'striptags';
-
-export function stripTags(text?: string) {
-    if (!text) {
-        return '';
-    }
-
-    return striptags(text);
-}


### PR DESCRIPTION
The main reason the build with the Next /app router was failing was due to `striptags` module. I figured out that we don't actually need it, since it's only used in places where React already escapes the HTML.

I also add `use client` directives to improve compatibility with React Server Components.