### PR TITLE
[DEV-12744] Feature - Do not use dangerouslySetInnerHTML

### DIFF
--- a/src/components/HtmlInjection.tsx
+++ b/src/components/HtmlInjection.tsx
@@ -18,23 +18,25 @@ export function HtmlInjection(props: Props) {
     const strippedHtml = useScripts(html, onError);
 
     useEffect(() => {
-        if (!containerRef.current || !onPlay) {
-            return;
-        }
+        if (containerRef.current) {
+            containerRef.current.innerHTML = strippedHtml;
 
-        import('player.js').then((playerjs) => {
-            const nodes = containerRef.current?.getElementsByTagName('iframe');
-            const iframes = Array.from(nodes ?? []);
-            iframes.forEach((iframe) => {
-                iframe.addEventListener('load', () => {
-                    const player = new playerjs.Player(iframe);
-                    player.on('play', onPlay);
+            if (onPlay) {
+                import('player.js').then((playerjs) => {
+                    const nodes = containerRef.current?.getElementsByTagName('iframe');
+                    const iframes = Array.from(nodes ?? []);
+                    iframes.forEach((iframe) => {
+                        iframe.addEventListener('load', () => {
+                            const player = new playerjs.Player(iframe);
+                            player.on('play', onPlay);
+                        });
+                    });
                 });
-            });
-        });
-    }, [onPlay]);
+            }
+        }
+    }, [onPlay, strippedHtml]);
 
-    return <div {...attrs} dangerouslySetInnerHTML={{ __html: strippedHtml }} ref={containerRef} />;
+    return <div {...attrs} ref={containerRef} />;
 }
 
 function useScripts(html: Props['html'], onError: Props['onError']) {


### PR DESCRIPTION
The problem with using `dangerouslySetInnerHTML` is that whenever the `HtmlInjection` component re-renders, it also re-renders the underlying Iframely embed.

So, if we need to track when media is played for example (via the `onPlay` callback), triggering this callback re-renders the component, which refreshes the iframe.