### PR TITLE
[CARE-4715] Fix - Update @prezly/uploadcare package

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "@prezly/linear-partition": "^1.0.2",
         "@prezly/sdk": "^20.0.0",
         "@prezly/story-content-format": "^0.64.0",
-        "@prezly/uploadcare": "^2.4.3",
+        "@prezly/uploadcare": "^2.4.4",
         "@react-hookz/web": "^12.0.0",
         "classnames": "^2.2.6",
         "player.js": "^0.1.0",


### PR DESCRIPTION
Update the `@prezly/uploadcare` dependency to fix the bug with incorrect image download URL.