### PR TITLE
[CARE-5666] Fix - Make tables responsive

### DIFF
--- a/src/elements/Table/Table.scss
+++ b/src/elements/Table/Table.scss
@@ -1,7 +1,13 @@
 @import "styles/variables";
 
+.prezly-slate-table-container {
+    width: 100%;
+    overflow-x: auto;
+}
+
 .prezly-slate-table {
     width: 100%;
+    max-width: 100%;
     border-collapse: collapse;
     table-layout: auto;
 
@@ -25,6 +31,7 @@
     outline: none !important;
     text-align: left;
     vertical-align: middle;
+    white-space: nowrap;
 
     > *:first-child {
         margin-top: 0;

--- a/src/elements/Table/Table.tsx
+++ b/src/elements/Table/Table.tsx
@@ -11,13 +11,15 @@ interface Props extends HTMLAttributes<HTMLTableElement> {
 export function Table({ children, node }: Props) {
     return (
         <TableContextProvider table={node}>
-            <table
-                className={classNames('prezly-slate-table', {
-                    'prezly-slate-table--withBorders': node.border,
-                })}
-            >
-                <tbody>{children}</tbody>
-            </table>
+            <div className="prezly-slate-table-container">
+                <table
+                    className={classNames('prezly-slate-table', {
+                        'prezly-slate-table--withBorders': node.border,
+                    })}
+                >
+                    <tbody>{children}</tbody>
+                </table>
+            </div>
         </TableContextProvider>
     );
 }

--- a/src/elements/Table/TableContext.tsx
+++ b/src/elements/Table/TableContext.tsx
@@ -31,11 +31,13 @@ export function useTableContext() {
 }
 
 function isFirstRow(table: TableNode, cell: TableCellNode): boolean {
-    return table.children[0]?.children.includes(cell);
+    return table.children[0]?.children.some(
+        (node) => JSON.stringify(node) === JSON.stringify(cell),
+    );
 }
 
 function isFirstColumn(table: TableNode, cell: TableCellNode): boolean {
-    return table.children.some((row) => row.children[0] === cell);
+    return table.children.some((row) => JSON.stringify(row.children[0]) === JSON.stringify(cell));
 }
 
 function isHeaderCell(table: TableNode, cell: TableCellNode): boolean {


### PR DESCRIPTION
Tables are now responsive and paragraphs in table cells are no longer wrapped automatically, so the table keeps the same format as in the editor.

I've also fixed the header cell detection that wasn't working before.

![Screenshot 2024-07-09 at 13 57 38](https://github.com/prezly/content-renderer-react-js/assets/4209081/9e223133-0069-49c3-b066-baff4aeae757)
