### PR TITLE
Fix - Revert responsive behaviour of tables

### DIFF
--- a/src/elements/Table/Table.scss
+++ b/src/elements/Table/Table.scss
@@ -1,13 +1,7 @@
 @import "styles/variables";
 
-.prezly-slate-table-container {
-    width: 100%;
-    overflow-x: auto;
-}
-
 .prezly-slate-table {
     width: 100%;
-    max-width: 100%;
     border-collapse: collapse;
     table-layout: auto;
 
@@ -31,7 +25,6 @@
     outline: none !important;
     text-align: left;
     vertical-align: middle;
-    white-space: nowrap;
 
     > *:first-child {
         margin-top: 0;

--- a/src/elements/Table/Table.tsx
+++ b/src/elements/Table/Table.tsx
@@ -11,15 +11,13 @@ interface Props extends HTMLAttributes<HTMLTableElement> {
 export function Table({ children, node }: Props) {
     return (
         <TableContextProvider table={node}>
-            <div className="prezly-slate-table-container">
-                <table
-                    className={classNames('prezly-slate-table', {
-                        'prezly-slate-table--withBorders': node.border,
-                    })}
-                >
-                    <tbody>{children}</tbody>
-                </table>
-            </div>
+            <table
+                className={classNames('prezly-slate-table', {
+                    'prezly-slate-table--withBorders': node.border,
+                })}
+            >
+                <tbody>{children}</tbody>
+            </table>
         </TableContextProvider>
     );
 }


### PR DESCRIPTION
Partially reverts #87 since the tables do not look great in production newsrooms with `white-space: nowrap` rule.
~It will still allow the table to be scrollable on smaller screens, but will preserve the same visuals for normal screens.~
Turns out the browser will still break the whitespace as needed, so the responsive behaviour does not seem to kick in in most cases. So just reverting that completely.