### PR TITLE
[CARE-5921] Fix - Bring back responsiveness functionality of tables

### DIFF
--- a/src/elements/Table/Table.scss
+++ b/src/elements/Table/Table.scss
@@ -1,7 +1,13 @@
 @import "styles/variables";
 
+.prezly-slate-table-container {
+    width: 100%;
+    overflow-x: auto;
+}
+
 .prezly-slate-table {
     width: 100%;
+    max-width: 100%;
     border-collapse: collapse;
     table-layout: auto;
 

--- a/src/elements/Table/Table.tsx
+++ b/src/elements/Table/Table.tsx
@@ -8,12 +8,14 @@ interface Props extends HTMLAttributes<HTMLTableElement> {
 
 export function Table({ children, node }: Props) {
     return (
-        <table
-            className={classNames('prezly-slate-table', {
-                'prezly-slate-table--withBorders': node.border,
-            })}
-        >
-            <tbody>{children}</tbody>
-        </table>
+        <div className="prezly-slate-table-container">
+            <table
+                className={classNames('prezly-slate-table', {
+                    'prezly-slate-table--withBorders': node.border,
+                })}
+            >
+                <tbody>{children}</tbody>
+            </table>
+        </div>
     );
 }


### PR DESCRIPTION
See ticket: [CARE-5921](https://linear.app/prezly/issue/CARE-5921/stannews-table-embed-does-not-adjust-for-stories-viewed-on-mobile)

Customer is complaining the table in mobile is not responsive.