### PR TITLE
[DEV-19805] Mark uncompressed files & images URL with `nofollow`

### DIFF
--- a/src/components/Lightbox/Lightbox.tsx
+++ b/src/components/Lightbox/Lightbox.tsx
@@ -130,8 +130,9 @@ export function Lightbox({
                     <div className="prezly-slate-lightbox__actions">
                         <a
                             className="prezly-slate-lightbox__download"
+                            download
                             href={image.downloadUrl}
-                            rel="noreferrer noopener"
+                            rel="nofollow noreferrer noopener"
                             target="_blank"
                             title="Download full-size"
                             onClick={() => onDownload(image)}
@@ -141,7 +142,7 @@ export function Lightbox({
 
                         <PinterestButton
                             className="prezly-slate-lightbox__pinterest"
-                            image={image.downloadUrl}
+                            image={previewImage(image).cdnUrl}
                         />
                     </div>
                 </div>

--- a/src/components/Rollover/Rollover.tsx
+++ b/src/components/Rollover/Rollover.tsx
@@ -42,7 +42,7 @@ export function Rollover({
     return (
         <a
             className={classNames('prezly-slate-image-rollover', className)}
-            onClick={function (event) {
+            onClick={(event) => {
                 event.preventDefault();
                 onClick();
             }}

--- a/src/elements/Attachment/Attachment.tsx
+++ b/src/elements/Attachment/Attachment.tsx
@@ -21,7 +21,9 @@ export function Attachment({ className, node, ...props }: Props) {
         <a
             id={`attachment-${file.uuid}`}
             className={classNames('prezly-slate-attachment', className)}
+            download
             href={attachment.downloadUrl}
+            rel="nofollow"
             {...props}
         >
             <div className="prezly-slate-attachment__content">


### PR DESCRIPTION
This is an attempt to reduce search indexing of large uncompressed files (including images: TIFs, and very large JPEGs).