### PR TITLE
[DEV-19806] Fix horizontal bookmark layout glitch

### DIFF
--- a/src/components/BookmarkCard/BookmarkCard.scss
+++ b/src/components/BookmarkCard/BookmarkCard.scss
@@ -12,6 +12,7 @@
 
         &.vertical {
             flex-flow: column;
+            align-items: start;
         }
 
         &.horizontal {


### PR DESCRIPTION
It happens when the title link is active & focused (as when you click a bookmark link from an email)