### PR TITLE
Fix - Do not render alt attribute on regular and gallery images

### DIFF
--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -46,7 +46,7 @@ export function Media({ className, image, style, title }: Props) {
 
     return (
         <img
-            alt={title}
+            alt={title ?? ''}
             className={computedClassName}
             src={image.format().cdnUrl}
             srcSet={[image.srcSet(1200), image.srcSet(800), image.srcSet(400)]

--- a/src/elements/Gallery/GalleryImage.tsx
+++ b/src/elements/Gallery/GalleryImage.tsx
@@ -32,11 +32,7 @@ export function GalleryImage({
             onClick={() => onClick(originalImage)}
             style={style}
         >
-            <Media
-                className="prezly-slate-gallery-image__media"
-                image={previewImage}
-                title={originalImage.caption}
-            />
+            <Media className="prezly-slate-gallery-image__media" image={previewImage} />
         </Rollover>
     );
 }

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -74,7 +74,7 @@ export function Image({ children, className, node, onDownload, onPreviewOpen, ..
                     {...(isNewTab ? NEW_TAB_ATTRIBUTES : {})}
                     style={containerStyle}
                 >
-                    <Media className="prezly-slate-image__media" image={image} title={title} />
+                    <Media className="prezly-slate-image__media" image={image} />
                 </a>
             )}
 
@@ -86,7 +86,7 @@ export function Image({ children, className, node, onDownload, onPreviewOpen, ..
                     onClick={handleRolloverClick}
                     style={containerStyle}
                 >
-                    <Media className="prezly-slate-image__media" image={image} title={title} />
+                    <Media className="prezly-slate-image__media" image={image} />
                 </Rollover>
             )}
 


### PR DESCRIPTION
Since we're rendering the captions next to the image, there's no need to repeat the `alt` attribute on the image.
I want to try this out and see if it makes the validator happy, otherwise I can revert it back if needed.

![Screenshot 2025-06-12 at 17 56 51](https://github.com/user-attachments/assets/cdc2b55d-a05c-4c1e-99b0-ae48073eb9ca)
