### PR TITLE
[DEV-21347] Fix - Properly support expanded tables

### DIFF
--- a/src/elements/Table/Table.scss
+++ b/src/elements/Table/Table.scss
@@ -3,6 +3,12 @@
 .prezly-slate-table-container {
     width: 100%;
     overflow-x: auto;
+
+    &--withFixedColumns {
+        width: min(var(--width), 100vw);
+        margin-left: 50%;
+        transform: translateX(-50%);
+    }
 }
 
 .prezly-slate-table {
@@ -13,8 +19,10 @@
 
     &--withFixedColumns {
         width: initial;
+        max-width: none;
+        margin-left: auto;
+        margin-right: auto;
         table-layout: fixed;
-        overflow-y: auto;
     }
 }
 

--- a/src/elements/Table/Table.tsx
+++ b/src/elements/Table/Table.tsx
@@ -1,18 +1,36 @@
 import type { TableNode } from '@prezly/story-content-format';
 import classNames from 'classnames';
-import type { HTMLAttributes } from 'react';
+import { useRef } from 'react';
+import type { CSSProperties, HTMLAttributes } from 'react';
 
 interface Props extends HTMLAttributes<HTMLTableElement> {
     node: TableNode;
 }
 
+const BORDER_WIDTH = 1;
+
 export function Table({ children, node }: Props) {
+    const ref = useRef<HTMLDivElement>(null);
+    const withFixedColumns = node.colSizes !== undefined;
+
+    const width =
+        typeof node.colSizes !== 'undefined'
+            ? node.colSizes.reduce((total, columnWidth) => total + columnWidth, BORDER_WIDTH)
+            : undefined;
+
     return (
-        <div className="prezly-slate-table-container">
+        <div
+            className={classNames('prezly-slate-table-container', {
+                'prezly-slate-table-container--withFixedColumns': withFixedColumns,
+            })}
+            ref={ref}
+            style={{ '--width': `${width}px` } as CSSProperties}
+        >
             <table
                 className={classNames('prezly-slate-table', {
-                    'prezly-slate-table--withFixedColumns': node.colSizes !== undefined,
+                    'prezly-slate-table--withFixedColumns': withFixedColumns,
                 })}
+                style={{ width }}
             >
                 <tbody>{children}</tbody>
             </table>


### PR DESCRIPTION
Fixed tables now properly expand outside of the container. If the viewport is smaller than the fixed table, the table becomes responsive.

<img width="948" height="1186" alt="Screenshot 2025-09-10 at 16 51 46" src="https://github.com/user-attachments/assets/9e0d71a1-27b8-431e-bdaf-8bcbf3ec16b8" />

<img width="794" height="1178" alt="Screenshot 2025-09-10 at 16 51 59" src="https://github.com/user-attachments/assets/00822d99-f12e-47fc-934a-f00d55767825" />
