### PR TITLE
[DEV-21757] Optimize filters to raw images

### DIFF
--- a/src/components/Lightbox/Lightbox.tsx
+++ b/src/components/Lightbox/Lightbox.tsx
@@ -142,7 +142,7 @@ export function Lightbox({
 
                         <PinterestButton
                             className="prezly-slate-lightbox__pinterest"
-                            image={previewImage(image).cdnUrl}
+                            image={previewImage(image).format().cdnUrl}
                         />
                     </div>
                 </div>

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -48,7 +48,7 @@ export function Media({ className, image, style, title }: Props) {
         <img
             alt={title ?? ''}
             className={computedClassName}
-            src={image.format().cdnUrl}
+            src={image.preview().format().cdnUrl}
             srcSet={[image.srcSet(1200), image.srcSet(800), image.srcSet(400)]
                 .filter(Boolean)
                 .join(', ')}

--- a/src/elements/Gallery/GalleryImage.tsx
+++ b/src/elements/Gallery/GalleryImage.tsx
@@ -28,7 +28,7 @@ export function GalleryImage({
                 'prezly-slate-gallery-image--with-border-radius': rounded,
             })}
             caption={originalImage.caption}
-            href={originalImage.cdnUrl}
+            href={originalImage.preview().format().cdnUrl}
             onClick={() => onClick(originalImage)}
             style={style}
         >

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -82,7 +82,7 @@ export function Image({ children, className, node, onDownload, onPreviewOpen, ..
                 <Rollover
                     id={`image-${file.uuid}`}
                     disabled={image.isGif()}
-                    href={image.cdnUrl}
+                    href={image.preview().format().cdnUrl}
                     onClick={handleRolloverClick}
                     style={containerStyle}
                 >


### PR DESCRIPTION
This ensures that hrefs that are normally ignored by normal browser usage (due to lightboxes) point to bandwidth-efficient resources.